### PR TITLE
Fix minor grammatical issues in Crosshair Calibration

### DIFF
--- a/docs/crosshair_calibration.rst
+++ b/docs/crosshair_calibration.rst
@@ -9,7 +9,7 @@ Calibrating a crosshair moves the "zero" of your targeting data. This is very us
 
 .. _Single-Crosshair:
 
-Single Crosshair Mode:
+Single Crosshair Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Line-up your robot at its ideal scoring location+rotation, and click "calibrate". Now a tx and ty of "zero" equate to a perfectly aligned robot. If your robot needs to be recalibrated for a new field, simply take a practice match to find the perfect alignment for your robot, and click "calibrate" during your match.
@@ -19,4 +19,4 @@ Line-up your robot at its ideal scoring location+rotation, and click "calibrate"
 Dual Crosshair Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Imagine a robot with an off-axis camera or shooter that needs to shoot gameobjects into a goal from many positions on the field. As the robot approaches the goal, its crosshair must adjust in real-time to compensate. Dual crosshair mode is built for this functionality. Line-up your robot at its closest scoring position+rotation, and calibrate crosshair "A". Line-up your robot at its farthest scoring position+rotation, and calibrate corsshair "B". When you calibrate in dual-crosshair mode, crosshairs also store an area value. You will notice that as your robot moves between its min and max scoring distances, the crosshair moves between crosshair "A" and crosshair "B". This is done by checking the area of the target, and comparing it to the two target areas seen during calibration.
+Imagine a robot with an off-axis camera or shooter that needs to shoot gameobjects into a goal from many positions on the field. As the robot approaches the goal, its crosshair must adjust in real-time to compensate. Dual crosshair mode is built for this functionality. Line-up your robot at its closest scoring position+rotation, and calibrate crosshair "A". Line-up your robot at its farthest scoring position+rotation, and calibrate crosshair "B". When you calibrate in dual-crosshair mode, crosshairs also store an area value. You will notice that as your robot moves between its min and max scoring distances, the crosshair moves between crosshair "A" and crosshair "B". This is done by checking the area of the target, and comparing it to the two target areas seen during calibration.


### PR DESCRIPTION
- Removes a colon from the end of the **Single Crosshair Mode** heading
- Changes "corsshair" to "crosshair"