### PR TITLE
Pitch, Roll, Yaw as opposed to X,Y,Z for rotation

### DIFF
--- a/docs/networktables_api.rst
+++ b/docs/networktables_api.rst
@@ -98,11 +98,11 @@ to retrieve this data:
 
 ======================== ============================================================================================================================================================================
 ------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-botpose   					Robot transform in field-space. Translation (X,Y,Z) Rotation(Pitch,Roll,Yaw)
+botpose   					Robot transform in field-space. Translation (X,Y,Z) Rotation(Roll,Pitch,Yaw)
 ------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-botpose_wpiblue  			Robot transform in field-space (blue driverstation WPILIB origin). Translation (X,Y,Z) Rotation(Pitch,Roll,Yaw)
+botpose_wpiblue  			Robot transform in field-space (blue driverstation WPILIB origin). Translation (X,Y,Z) Rotation(Roll,Pitch,Yaw)
 ------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-botpose_wpired   			Robot transform in field-space (red driverstation WPILIB origin). Translation (X,Y,Z) Rotation(Pitch,Roll,Yaw)
+botpose_wpired   			Robot transform in field-space (red driverstation WPILIB origin). Translation (X,Y,Z) Rotation(Roll,Pitch,Yaw)
 ------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 camerapose_targetspace   	3D transform of the camera in the coordinate system of the primary in-view AprilTag (array (6))
 ------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/docs/networktables_api.rst
+++ b/docs/networktables_api.rst
@@ -98,11 +98,11 @@ to retrieve this data:
 
 ======================== ============================================================================================================================================================================
 ------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-botpose   					Robot transform in field-space. Translation (X,Y,Z) Rotation(X,Y,Z)
+botpose   					Robot transform in field-space. Translation (X,Y,Z) Rotation(Pitch,Roll,Yaw)
 ------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-botpose_wpiblue  			Robot transform in field-space (blue driverstation WPILIB origin). Translation (X,Y,Z) Rotation(X,Y,Z)
+botpose_wpiblue  			Robot transform in field-space (blue driverstation WPILIB origin). Translation (X,Y,Z) Rotation(Pitch,Roll,Yaw)
 ------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-botpose_wpired   			Robot transform in field-space (red driverstation WPILIB origin). Translation (X,Y,Z) Rotation(X,Y,Z)
+botpose_wpired   			Robot transform in field-space (red driverstation WPILIB origin). Translation (X,Y,Z) Rotation(Pitch,Roll,Yaw)
 ------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 camerapose_targetspace   	3D transform of the camera in the coordinate system of the primary in-view AprilTag (array (6))
 ------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
After going through the Limelight documentation, I came across "botpose" and noticed it states it returns Rotation in terms of "X, Y, Z". This was perplexing as it is very different from the expected "pitch, roll, yaw" and has caused me some confusion. After realizing this must be a minor mistake, the error vexed me for a while causing difficulty concentrating on the rest of the file. Thank you for your time and amazing work on this documentation as a whole: it has been extremely helpful!