### PR TITLE
Limelight Typo

### DIFF
--- a/docs/apriltags_in_3d.rst
+++ b/docs/apriltags_in_3d.rst
@@ -71,7 +71,7 @@ As the 3D combined MegaTag increases in size and in keypoint count, its stabilit
 
 Using WPILib's Pose Estimator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The latest images for LImelight publish targeting latency and capture latency in milliseconds. You can access them with the "tl" and "cl" NT keys, or with LimelightHelpers.getLatency_Pipeline() and LimelightHelpers.getLatency_Capture() if you are using Limelight Lib. You can also get the combined latency by accessing the 7th value in the botpose array.
+The latest images for Limelight publish targeting latency and capture latency in milliseconds. You can access them with the "tl" and "cl" NT keys, or with LimelightHelpers.getLatency_Pipeline() and LimelightHelpers.getLatency_Capture() if you are using Limelight Lib. You can also get the combined latency by accessing the 7th value in the botpose array.
 
 pseudocode for the "latency" component of WPILib' addVisionMeasurement():
 


### PR DESCRIPTION
This typo in which Limelight is spelt "LImelight" distracts from the bank of cognizance that awaits the reader. Thank you for your time.